### PR TITLE
docs: add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+# Contributing
+
+- Code should follow the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
+- Commit messages should conform to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
+- Commits should be well-scoped.
+    - ex: `feat: add foo` instead of `Add foo`
+- Commits should not be capitalized.
+    - ex `feat: add foo` instead of `feat: Add foo`


### PR DESCRIPTION
without this, I foresee arguments about code style/formatting and commit message standards...

Closes #2